### PR TITLE
added perfect wins

### DIFF
--- a/src/main/java/io/github/restioson/koth/game/KothActive.java
+++ b/src/main/java/io/github/restioson/koth/game/KothActive.java
@@ -70,6 +70,7 @@ public class KothActive {
     private final Optional<KothTimerBar> timerBar;
     private final KothScoreboard scoreboard;
     private OvertimeState overtimeState = OvertimeState.NOT_IN_OVERTIME;
+    private int totalWins = 0;
     private boolean gameFinished;
     private static final int LEAP_INTERVAL_TICKS = 5 * 20; // 5 second cooldown
     private static final double LEAP_VELOCITY = 1.0;
@@ -478,6 +479,7 @@ public class KothActive {
         if (participant != null) {
             participant.wins++;
         }
+        totalWins++;
 
         String wonThe;
 
@@ -486,6 +488,9 @@ public class KothActive {
             this.gameFinished = true;
         } else if (participant != null && (participant.wins == this.config.firstTo() || this.config.knockoff())) {
             wonThe = "game";
+            if (participant.wins == totalWins) {
+                wonThe += " perfectly";
+            }
             this.gameFinished = true;
         } else {
             wonThe = "round";


### PR DESCRIPTION
In deathmatch games, if the same player wins all rounds, then the win message is indicated as a perfect win. (Fixes #57 )

![image](https://user-images.githubusercontent.com/69263168/200708198-fade412e-7e77-43b0-86f8-b36ed5b1267f.png)
