### PR TITLE
Indicate players currently on the throne on the scoreboard

### DIFF
--- a/src/main/java/io/github/restioson/koth/game/KothScoreboard.java
+++ b/src/main/java/io/github/restioson/koth/game/KothScoreboard.java
@@ -2,6 +2,7 @@ package io.github.restioson.koth.game;
 
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.math.Box;
 import xyz.nucleoid.plasmid.game.common.GlobalWidgets;
 import xyz.nucleoid.plasmid.game.common.widget.SidebarWidget;
 
@@ -27,7 +28,7 @@ public class KothScoreboard {
         });
     }
 
-    public void render(List<KothPlayer> leaderboard) {
+    public void render(List<KothPlayer> leaderboard, Box throne) {
         this.sidebar.set(content -> {
             for (KothPlayer entry : leaderboard) {
                 String line;
@@ -45,6 +46,17 @@ public class KothScoreboard {
                 } else if (this.knockoff) {
                     line = String.format(
                             "%s%s%s: %d points",
+                            Formatting.AQUA,
+                            entry.player.getEntityName(),
+                            Formatting.RESET,
+                            entry.score
+                    );
+                } else if (throne.intersects(entry.player.getBoundingBox())) {
+                    Formatting indicatorColor = entry.player.getWorld().getTime() % 20 == 0 ? Formatting.GOLD : Formatting.YELLOW;
+
+                    line = String.format(
+                            "%s♦ %s%s%s: %ds",
+                            indicatorColor,
                             Formatting.AQUA,
                             entry.player.getEntityName(),
                             Formatting.RESET,

--- a/src/main/java/io/github/restioson/koth/game/map/KothMap.java
+++ b/src/main/java/io/github/restioson/koth/game/map/KothMap.java
@@ -3,6 +3,7 @@ package io.github.restioson.koth.game.map;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.util.Util;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.Box;
 import net.minecraft.util.math.random.Random;
 import net.minecraft.world.gen.chunk.ChunkGenerator;
 import xyz.nucleoid.map_templates.BlockBounds;
@@ -18,14 +19,14 @@ public class KothMap {
     public final int spawnAngle;
     public final BlockBounds bounds;
     public final List<BlockBounds> noPvp;
-    public final BlockBounds throne;
+    public final Box throne;
 
     public KothMap(MapTemplate template, List<BlockBounds> spawns, BlockBounds throne, int spawnAngle) {
         this.template = template;
         this.spawns = spawns;
         this.spawnAngle = spawnAngle;
         this.bounds = template.getBounds();
-        this.throne = throne;
+        this.throne = throne.asBox();
 
         this.noPvp = new ArrayList<>(spawns.size());
         for (BlockBounds spawn : spawns) {


### PR DESCRIPTION
With this pull request, a flashing indicator will appear next to players' names on the scoreboard to indicate that they are on the throne.

<img width="522" alt="Scoreboard with throne indicator" src="https://github.com/NucleoidMC/koth/assets/24855774/873f6cee-d671-4707-be30-95d4326e95df">