### PR TITLE
Fix short names not using translatable text

### DIFF
--- a/src/main/resources/data/koth/games/birthday_cake.json
+++ b/src/main/resources/data/koth/games/birthday_cake.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.birthday_cake.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/blommor.json
+++ b/src/main/resources/data/koth/games/blommor.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.blommor.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/buttons.json
+++ b/src/main/resources/data/koth/games/buttons.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.buttons.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/castle.json
+++ b/src/main/resources/data/koth/games/castle.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.castle.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/cotton_candy_scored.json
+++ b/src/main/resources/data/koth/games/cotton_candy_scored.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.cotton_candy_scored.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/cotton_candy_scored_bow.json
+++ b/src/main/resources/data/koth/games/cotton_candy_scored_bow.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.cotton_candy_scored_bow.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/cotton_candy_scored_leap.json
+++ b/src/main/resources/data/koth/games/cotton_candy_scored_leap.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.cotton_candy_scored_leap.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/cotton_candy_wta.json
+++ b/src/main/resources/data/koth/games/cotton_candy_wta.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.cotton_candy_wta.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/cube.json
+++ b/src/main/resources/data/koth/games/cube.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 2}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.cube.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/dark_hills.json
+++ b/src/main/resources/data/koth/games/dark_hills.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 2}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.dark_hills.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/deathmatch.json
+++ b/src/main/resources/data/koth/games/deathmatch.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.deathmatch.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/deathmatch_secret.json
+++ b/src/main/resources/data/koth/games/deathmatch_secret.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.deathmatch_secret.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/diamond.json
+++ b/src/main/resources/data/koth/games/diamond.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.diamond.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/dice.json
+++ b/src/main/resources/data/koth/games/dice.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.dice.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/dynasty.json
+++ b/src/main/resources/data/koth/games/dynasty.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.dynasty.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/end_city.json
+++ b/src/main/resources/data/koth/games/end_city.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.end_city.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/hill_fort.json
+++ b/src/main/resources/data/koth/games/hill_fort.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.hill_fort.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/ice.json
+++ b/src/main/resources/data/koth/games/ice.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.ice.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/ice_knockoff.json
+++ b/src/main/resources/data/koth/games/ice_knockoff.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.ice_knockoff.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.knockoff.1"

--- a/src/main/resources/data/koth/games/industrial.json
+++ b/src/main/resources/data/koth/games/industrial.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.industrial.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/island.json
+++ b/src/main/resources/data/koth/games/island.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.island.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/jungle_hideout.json
+++ b/src/main/resources/data/koth/games/jungle_hideout.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.jungle_hideout.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/knockback_colosseum.json
+++ b/src/main/resources/data/koth/games/knockback_colosseum.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.knockback_colosseum.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/lifebuoy.json
+++ b/src/main/resources/data/koth/games/lifebuoy.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.lifebuoy.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/lone_moat.json
+++ b/src/main/resources/data/koth/games/lone_moat.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.lone_moat.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/monolith.json
+++ b/src/main/resources/data/koth/games/monolith.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.monolith.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/pyramid.json
+++ b/src/main/resources/data/koth/games/pyramid.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 2}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.pyramid.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/romantica.json
+++ b/src/main/resources/data/koth/games/romantica.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 2}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.romantica.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/skyland.json
+++ b/src/main/resources/data/koth/games/skyland.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.skyland.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/squares.json
+++ b/src/main/resources/data/koth/games/squares.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.squares.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/stack.json
+++ b/src/main/resources/data/koth/games/stack.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.stack.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/stack_bow.json
+++ b/src/main/resources/data/koth/games/stack_bow.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.stack_bow.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/stack_leap.json
+++ b/src/main/resources/data/koth/games/stack_leap.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.stack_leap.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/strawberry_dough.json
+++ b/src/main/resources/data/koth/games/strawberry_dough.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.strawberry_dough.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/stronghold_library.json
+++ b/src/main/resources/data/koth/games/stronghold_library.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.stronghold_library.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },

--- a/src/main/resources/data/koth/games/swamp.json
+++ b/src/main/resources/data/koth/games/swamp.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.swamp.short"
+  },
   "description": [
     {
       "translate": "gameType.koth.koth.desc.1"

--- a/src/main/resources/data/koth/games/weathered_wave.json
+++ b/src/main/resources/data/koth/games/weathered_wave.json
@@ -4,7 +4,9 @@
     "id": "minecraft:stick", "Count": 1,
     "Enchantments": [{"id": "minecraft:knockback", "lvl": 1}]
   },
-  "short_name": "gameType.koth.koth.short",
+  "short_name": {
+    "translate": "game.koth.weathered_wave.short"
+  },
   "description": {
     "translate": "gameType.koth.koth.desc.deathmatch"
   },


### PR DESCRIPTION
Short names had the same issue as #93 of not using translatable text. This pull request changes short names to use translatable text with the proper translation key.